### PR TITLE
Add ThreatCluster public IOC feed (domains + IPs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ Terms of Service: https://ellio.tech/beta-terms-and-conditions
 - https://nocdn.threat-list.com/0/domains.txt
 - https://dl.threat-list.com/1/domains.txt
 
+# threatcluster.io
+
+- https://threatcluster.io/api/iocs/public/feed.txt
+- https://threatcluster.io/api/iocs/public/feed.csv
+
 # threatview.io
 - https://threatview.io/Downloads/Experimental-IOC-Tweets.txt
 - https://threatview.io/Downloads/High-Confidence-CobaltStrike-C2%20-Feeds.txt

--- a/Scripts/StatisticsTable.md
+++ b/Scripts/StatisticsTable.md
@@ -1,6 +1,6 @@
 | Category | Count |
 | --- | --- |
-| DNS | 15 |
+| DNS | 16 |
 | IP | 76 |
 | MD5 | 11 |
 | SHA1 | 4 |

--- a/ThreatIntelFeeds.csv
+++ b/ThreatIntelFeeds.csv
@@ -143,3 +143,4 @@ mthcht;Proton VPN IP List;IP;https://github.com/mthcht/awesome-lists/blob/main/L
 Daniel Austin MBCS;TOR Exit Nodes;IP;https://www.dan.me.uk/torlist/?exit;Active
 Daniel Austin MBCS;TOR All Nodes;IP;https://www.dan.me.uk/torlist/?full;Active
 Spamhaus Project;Don't Route Or Peer Lists (DROP);IP;https://www.spamhaus.org/drop/drop_v4.json;Active
+ThreatCluster;High-confidence malicious domains extracted from threat intel reports as they are published;DNS;https://threatcluster.io/api/iocs/public/feed.txt;Active


### PR DESCRIPTION
Adds ThreatCluster's public IOC blocklist: high-confidence malicious domains and IPs extracted from threat-intel reports as they're published